### PR TITLE
consider examples for parameter values

### DIFF
--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -140,17 +140,25 @@ const createQueryStringObjects = function (
   return [{ name, value: value + '' }];
 };
 
+/**
+ * Returns `value` formatted properly for a path parameter with given values of
+ * `style` and `explode`
+ * @param {string} name
+ * @param {*} value
+ * @param {string} style
+ * @param {boolean} explode
+ * @returns {string} Returns `value` formatted properly for the specified path parameter
+ */
 const getParameterValueFromExampleForPath = function (
   name,
-  example,
-  location,
+  value,
   style,
   explode
 ) {
   const queryStringObjects = createQueryStringObjects(
     name,
-    example,
-    location,
+    value,
+    'path',
     style,
     explode
   );
@@ -158,7 +166,7 @@ const getParameterValueFromExampleForPath = function (
   if (queryStringObjects.length > 1) {
     // We are dealing with an exploded parameter, check the example
     // to see if it's an array or an object as they explode differently
-    if (Array.isArray(example)) {
+    if (Array.isArray(value)) {
       return queryStringObjects.map((entry) => entry.value) + '';
     } else {
       return queryStringObjects.map((qs) => `${qs.name}=${qs.value}`) + '';
@@ -552,7 +560,6 @@ const getFullPath = function (openApi, path, method) {
             getParameterValueFromExampleForPath(
               param.name,
               param.example,
-              param.in,
               param.style,
               param.explode
             )
@@ -569,7 +576,6 @@ const getFullPath = function (openApi, path, method) {
                 getParameterValueFromExampleForPath(
                   param.name,
                   example,
-                  param.in,
                   param.style,
                   param.explode,
                   defaultValue

--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -544,7 +544,10 @@ const getHeadersArray = function (openApi, path, method) {
   // headers defined in path object:
   if (typeof pathObj.parameters !== 'undefined') {
     for (let k in pathObj.parameters) {
-      const param = pathObj.parameters[k];
+      let param = pathObj.parameters[k];
+      if (typeof param['$ref'] === 'string' && /^#/.test(param['$ref'])) {
+        param = resolveRef(openApi, param['$ref']);
+      }
       if (
         typeof param.in !== 'undefined' &&
         param.in.toLowerCase() === 'header'

--- a/test/parameter_example_swagger.json
+++ b/test/parameter_example_swagger.json
@@ -32,7 +32,11 @@
             "description": "tags to filter by",
             "required": false,
             "style": "form",
-            "example": ["dog", "cat"],
+            "explode": false,
+            "example": [
+              "dog",
+              "cat"
+            ],
             "schema": {
               "type": "array",
               "items": {
@@ -84,7 +88,11 @@
           "description": "tags to filter by",
           "required": false,
           "style": "form",
-          "example": ["dog", "cat"],
+          "explode": false,
+          "example": [
+            "dog",
+            "cat"
+          ],
           "schema": {
             "type": "array",
             "items": {
@@ -153,7 +161,11 @@
             "in": "query",
             "description": "A comma-seperated list of species IDs",
             "required": false,
-            "example": [1, 2],
+            "explode": false,
+            "example": [
+              1,
+              2
+            ],
             "schema": {
               "type": "array",
               "items": {
@@ -195,7 +207,9 @@
             "$ref": "#/components/schemas/NewPet"
           },
           {
-            "required": ["id"],
+            "required": [
+              "id"
+            ],
             "properties": {
               "id": {
                 "type": "integer",
@@ -206,7 +220,9 @@
         ]
       },
       "NewPet": {
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -223,7 +239,9 @@
         "type": "array"
       },
       "Thing": {
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "properties": {
           "id": {
             "type": "integer"
@@ -231,7 +249,10 @@
         }
       },
       "Error": {
-        "required": ["code", "message"],
+        "required": [
+          "code",
+          "message"
+        ],
         "properties": {
           "code": {
             "type": "integer",

--- a/test/parameter_variations_swagger.json
+++ b/test/parameter_variations_swagger.json
@@ -1,0 +1,357 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Swagger Petstore",
+        "description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification",
+        "termsOfService": "http://swagger.io/terms/",
+        "contact": {
+            "name": "Swagger API Team",
+            "email": "apiteam@swagger.io",
+            "url": "http://swagger.io"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+        }
+    },
+    "servers": [
+        {
+            "url": "http://petstore.swagger.io/api"
+        }
+    ],
+    "paths": {
+        "/pets": {
+            "get": {
+                "description": "Get Pets from store",
+                "operationId": "getPet",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "style": "simple",
+                        "default": [
+                            13,
+                            23
+                        ],
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "style": "form",
+                        "explode": false,
+                        "description": "tags to filter by",
+                        "required": false,
+                        "example": [
+                            "dog",
+                            "cat"
+                        ],
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "maximum number of results to return",
+                        "example": 10,
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Pet"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/pets/{id}": {
+            "get": {
+                "description": "Get Pets from store",
+                "operationId": "getPet",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "style": "simple",
+                        "default": [
+                            13,
+                            23
+                        ],
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "style": "form",
+                        "explode": false,
+                        "description": "tags to filter by",
+                        "required": false,
+                        "example": [
+                            "dog",
+                            "cat"
+                        ],
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "maximum number of results to return",
+                        "example": 10,
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Pet"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/animals": {
+            "parameters": [
+                {
+                    "name": "tags",
+                    "in": "query",
+                    "description": "tags to filter by",
+                    "required": false,
+                    "style": "form",
+                    "explode": false,
+                    "example": [
+                        "dog",
+                        "cat"
+                    ],
+                    "schema": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                {
+                    "name": "limit",
+                    "in": "query",
+                    "description": "maximum number of results to return",
+                    "example": 10,
+                    "required": false,
+                    "schema": {
+                        "type": "integer",
+                        "format": "int32"
+                    }
+                }
+            ],
+            "get": {
+                "description": "Get Pets from store",
+                "operationId": "getPet",
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Pet"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/species": {
+            "parameters": [
+                {
+                    "name": "id",
+                    "in": "query",
+                    "description": "the species id",
+                    "required": false,
+                    "example": 1,
+                    "schema": {
+                        "type": "integer"
+                    }
+                }
+            ],
+            "get": {
+                "description": "Get Pets from store",
+                "operationId": "getPet",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "A comma-seperated list of species IDs",
+                        "required": false,
+                        "explode": false,
+                        "example": [
+                            1,
+                            2
+                        ],
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Species"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Pet": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/NewPet"
+                    },
+                    {
+                        "required": [
+                            "id"
+                        ],
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "format": "int64"
+                            }
+                        }
+                    }
+                ]
+            },
+            "NewPet": {
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "tag": {
+                        "type": "string"
+                    }
+                }
+            },
+            "Species": {
+                "items": {
+                    "$ref": "#/components/thing"
+                },
+                "type": "array"
+            },
+            "Thing": {
+                "required": [
+                    "id"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "Error": {
+                "required": [
+                    "code",
+                    "message"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "message": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -450,23 +450,6 @@ test('Parameter in query, form style, no explode, default value 75', function (t
   t.end();
 });
 
-test('Parameter in query, simple style, no explode, default value 75', function (t) {
-  let testScenario = {
-    api: ParameterVariationsAPI,
-    path: '/pets',
-    method: 'get',
-    parameterName: 'id',
-    locationOfParameter: 'query',
-    locationOfExample: 'default',
-    style: 'simple',
-    explode: undefined,
-    value: 75,
-    expectedString: /id: '75'/,
-  };
-  runParameterTest(t, testScenario);
-  t.end();
-});
-
 test('Parameter in query, no style, no explode, example value 75', function (t) {
   let testScenario = {
     api: ParameterVariationsAPI,
@@ -501,23 +484,6 @@ test('Parameter in query, form style, no explode, example value 75', function (t
   t.end();
 });
 
-test('Parameter in query, simple style, no explode, example value 75', function (t) {
-  let testScenario = {
-    api: ParameterVariationsAPI,
-    path: '/pets',
-    method: 'get',
-    parameterName: 'id',
-    locationOfParameter: 'query',
-    locationOfExample: 'example',
-    style: 'simple',
-    explode: undefined,
-    value: 75,
-    expectedString: /id: '75'/,
-  };
-  runParameterTest(t, testScenario);
-  t.end();
-});
-
 test('Parameter in query, no style, no explode, examples value 75', function (t) {
   let testScenario = {
     api: ParameterVariationsAPI,
@@ -544,23 +510,6 @@ test('Parameter in query, form style, no explode, examples value 75', function (
     locationOfParameter: 'query',
     locationOfExample: 'examples',
     style: 'form',
-    explode: undefined,
-    value: 75,
-    expectedString: /id: '75'/,
-  };
-  runParameterTest(t, testScenario);
-  t.end();
-});
-
-test('Parameter in query, simple style, no explode, examples value 75', function (t) {
-  let testScenario = {
-    api: ParameterVariationsAPI,
-    path: '/pets',
-    method: 'get',
-    parameterName: 'id',
-    locationOfParameter: 'query',
-    locationOfExample: 'examples',
-    style: 'simple',
     explode: undefined,
     value: 75,
     expectedString: /id: '75'/,
@@ -639,40 +588,6 @@ test('Parameter in query, form style, explode true, default value [75, 23]', fun
   t.end();
 });
 
-test('Parameter in query, simple style, no explode (ignored), default value [75,23]', function (t) {
-  let testScenario = {
-    api: ParameterVariationsAPI,
-    path: '/pets',
-    method: 'get',
-    parameterName: 'id',
-    locationOfParameter: 'query',
-    locationOfExample: 'default',
-    style: 'simple',
-    explode: undefined,
-    value: [75, 23],
-    expectedString: /id: '75,23'/,
-  };
-  runParameterTest(t, testScenario);
-  t.end();
-});
-
-test('Parameter in query, simple style, explode true (ignored), default value [75,23]', function (t) {
-  let testScenario = {
-    api: ParameterVariationsAPI,
-    path: '/pets',
-    method: 'get',
-    parameterName: 'id',
-    locationOfParameter: 'query',
-    locationOfExample: 'default',
-    style: 'simple',
-    explode: true,
-    value: [75, 23],
-    expectedString: /id: '75,23'/,
-  };
-  runParameterTest(t, testScenario);
-  t.end();
-});
-
 // Array Query Parameter Tests - Example Value
 
 test('Parameter in query, no style (defaults form), no explode (defaults true), default value [75, 23]', function (t) {
@@ -721,40 +636,6 @@ test('Parameter in query, form style, explode true, default value [75, 23]', fun
     explode: true,
     value: [75, 23],
     expectedString: /id: \['75', '23']/,
-  };
-  runParameterTest(t, testScenario);
-  t.end();
-});
-
-test('Parameter in query, simple style, no explode (ignored), default value [75,23]', function (t) {
-  let testScenario = {
-    api: ParameterVariationsAPI,
-    path: '/pets',
-    method: 'get',
-    parameterName: 'id',
-    locationOfParameter: 'query',
-    locationOfExample: 'example',
-    style: 'simple',
-    explode: undefined,
-    value: [75, 23],
-    expectedString: /id: '75,23'/,
-  };
-  runParameterTest(t, testScenario);
-  t.end();
-});
-
-test('Parameter in query, simple style, explode true (ignored), default value [75,23]', function (t) {
-  let testScenario = {
-    api: ParameterVariationsAPI,
-    path: '/pets',
-    method: 'get',
-    parameterName: 'id',
-    locationOfParameter: 'query',
-    locationOfExample: 'example',
-    style: 'simple',
-    explode: true,
-    value: [75, 23],
-    expectedString: /id: '75,23'/,
   };
   runParameterTest(t, testScenario);
   t.end();
@@ -813,40 +694,6 @@ test('Parameter in query, form style, explode true, default value [75, 23]', fun
   t.end();
 });
 
-test('Parameter in query, simple style, no explode (ignored), default value [75,23]', function (t) {
-  let testScenario = {
-    api: ParameterVariationsAPI,
-    path: '/pets',
-    method: 'get',
-    parameterName: 'id',
-    locationOfParameter: 'query',
-    locationOfExample: 'examples',
-    style: 'simple',
-    explode: undefined,
-    value: [75, 23],
-    expectedString: /id: '75,23'/,
-  };
-  runParameterTest(t, testScenario);
-  t.end();
-});
-
-test('Parameter in query, simple style, explode true (ignored), default value [75,23]', function (t) {
-  let testScenario = {
-    api: ParameterVariationsAPI,
-    path: '/pets',
-    method: 'get',
-    parameterName: 'id',
-    locationOfParameter: 'query',
-    locationOfExample: 'examples',
-    style: 'simple',
-    explode: true,
-    value: [75, 23],
-    expectedString: /id: '75,23'/,
-  };
-  runParameterTest(t, testScenario);
-  t.end();
-});
-
 // Object Query Parameter Tests
 
 test('Parameter in query, no style (defaults form), no explode (defaults true), default value {R:100,G:230,B:19}', function (t) {
@@ -895,23 +742,6 @@ test('Parameter in query, form style, explode true, default value {R:100,G:230,B
     explode: true,
     value: { R: 100, G: 230, B: 19 },
     expectedString: /R: '100', G: '230', B: '19'/,
-  };
-  runParameterTest(t, testScenario);
-  t.end();
-});
-
-test('Parameter in query, simple style, no explode (ignored), default value {R:100,G:230,B:19}', function (t) {
-  let testScenario = {
-    api: ParameterVariationsAPI,
-    path: '/pets',
-    method: 'get',
-    parameterName: 'id',
-    locationOfParameter: 'query',
-    locationOfExample: 'default',
-    style: 'simple',
-    explode: undefined,
-    value: { R: 100, G: 230, B: 19 },
-    expectedString: /id: 'R,100,G,230,B,19'/,
   };
   runParameterTest(t, testScenario);
   t.end();
@@ -972,101 +802,38 @@ test('Parameter in path, no style (defaults simple), explode true, example value
   t.end();
 });
 
-// test('Parameter in query, no style, no explode, default value 75', function (t) {
-//   t.plan(7);
+// Object Path Parameter Tests
 
-//   // Test all the variations of query parameters
-//   // value: array, object, primitive
-//   // parameter key: default, example, examples (and $ref versions)
-//   // style: form, simple, _missing_
-//   // explode: true, false, _missing_
+test('Parameter in path, no style (defaults simple), explode true, example value {R: 150, G: 100, B: 225}', function (t) {
+  let testScenario = {
+    api: ParameterVariationsAPI,
+    path: '/pets/{id}',
+    method: 'get',
+    parameterName: 'id',
+    locationOfParameter: 'path',
+    locationOfExample: 'example',
+    style: undefined,
+    explode: true,
+    value: { R: 150, G: 100, B: 225 },
+    expectedString: /\/pets\/R=150,G=100,B=225/,
+  };
+  runParameterTest(t, testScenario);
+  t.end();
+});
 
-//   testScenario = Object.assign({}, baseScenario, {
-//     value: 'dog',
-//     expectedString: /id=dog/,
-//   });
-//   runParameterTest(t, testScenario);
-
-//   // Default style of query is form, default of explode is true for form
-//   testScenario = Object.assign({}, baseScenario, {
-//     value: [75, 23],
-//     expectedString: /id=75&id=23/,
-//   });
-//   runParameterTest(t, testScenario);
-
-//   testScenario = Object.assign({}, baseScenario, {
-//     value: [75, 14],
-//     expectedString: /id=75%2C14/,
-//     explode: false,
-//   });
-//   runParameterTest(t, testScenario);
-
-//   testScenario = Object.assign({}, baseScenario, {
-//     value: [175, 223],
-//     style: 'simple',
-//     expectedString: /id=175%2C223/,
-//   });
-//   runParameterTest(t, testScenario);
-
-//   testScenario = Object.assign({}, baseScenario, {
-//     value: { R: 100, B: 230, C: 19 },
-//     style: 'simple',
-//     expectedString: /id=R%2C100%2CB%2C230%2CC%2C19/,
-//   });
-//   runParameterTest(t, testScenario);
-
-//   testScenario = Object.assign({}, baseScenario, {
-//     value: { R: 100, B: 230, C: 19 },
-//     style: 'form',
-//     expectedString: /R=100&B=230&C=19/,
-//   });
-//   runParameterTest(t, testScenario);
-
-//   t.end();
-// });
-
-// test('Query Parameters', function (t) {
-//   t.plan(1);
-
-//   // Test all the variations of
-//   // value: array, object, primitive
-//   // parameter key: example, examples (and $ref versions)
-//   // style: form, simple
-//   // in: path, query, header
-//   // exploded: true, false
-
-//   // make a clone so other tests are not impacted
-//   const api = JSON.parse(JSON.stringify(ParameterExampleReferenceAPI));
-
-//   api.paths['/pets'].get.parameters[0].explode = true;
-
-//   const result = OpenAPISnippets.getEndpointSnippets(api, '/pets', 'get', [
-//     'shell_curl',
-//   ]);
-//   const snippet = result.snippets[0].content;
-//   t.true(/tags=dog&tags=cat/.test(snippet));
-//   t.end();
-// });
-
-// test('Header Parameters', function (t) {
-//   t.plan(1);
-
-//   // Test all the variations of
-//   // value: array, object, primitive
-//   // parameter key: example, examples (and $ref versions)
-//   // style: form, simple
-//   // in: path, query, header
-//   // exploded: true, false
-
-//   // make a clone so other tests are not impacted
-//   const api = JSON.parse(JSON.stringify(ParameterExampleReferenceAPI));
-
-//   api.paths['/pets'].get.parameters[0].explode = true;
-
-//   const result = OpenAPISnippets.getEndpointSnippets(api, '/pets', 'get', [
-//     'shell_curl',
-//   ]);
-//   const snippet = result.snippets[0].content;
-//   t.true(/tags=dog&tags=cat/.test(snippet));
-//   t.end();
-// });
+test('Parameter in path, no style (defaults simple), no explode (defaults false), example value {R: 150, G: 100, B: 225}', function (t) {
+  let testScenario = {
+    api: ParameterVariationsAPI,
+    path: '/pets/{id}',
+    method: 'get',
+    parameterName: 'id',
+    locationOfParameter: 'path',
+    locationOfExample: 'example',
+    style: undefined,
+    explode: undefined,
+    value: { R: 150, G: 100, B: 225 },
+    expectedString: /\/pets\/R,150,G,100,B,225/,
+  };
+  runParameterTest(t, testScenario);
+  t.end();
+});


### PR DESCRIPTION
If `example` isn't set for a parameter, then go ahead
and check for `examples`. If that is present, then use the
value from the first entry as the parameter value.

Note: The value of the fist entry must have type `string`.
If no suitable value is found, then the code snippet
will not have a value.

Fix ErikWittern#81If `example` isn't set for a parameter, then go ahead
and check for `examples`. If that is present, then use the
value from the first entry as the parameter value.

Note: The value of the fist entry must have type `string`.
If no suitable value is found, then the code snippet
will not have a value.

Fix #81